### PR TITLE
Improving Robustness

### DIFF
--- a/thermoscope-bluefruit.ino
+++ b/thermoscope-bluefruit.ino
@@ -62,10 +62,11 @@ Adafruit_BLEBattery battery(ble);
 void error(const __FlashStringHelper*err) {
   Serial.println(err);
   while (1){
-    digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
-    delay(50);                       // wait for a 0.1 seconds
-    digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
-    delay(50);                       // wait for a 0.1 seconds
+    // Flicker the LED 50ms on 50ms off
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(50);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(50);
   }
 }
 


### PR DESCRIPTION
- add version characteristic so the version of firmware is exposed
- rapidly flash LED when there is an error
- blink LED one time when our sketch starts running
- turn off the LED when the setup of the sketch is done
- check for an error when turning off the echo, if so, try a reset
- make sure the module has at least firmware 0.7.7
- add error checking to readNVM (however the Adafruit readNVM doesn't handle errors well)
- adjust the battery percentage computation. Assume 3 AAA batteries so 100% is 4.8