### PR TITLE
Changed the icon characteristic to allow writeWithoutResponse 

### DIFF
--- a/thermoscope-bluefruit.ino
+++ b/thermoscope-bluefruit.ino
@@ -446,7 +446,8 @@ void setup(void) {
   }
 
   // Add icon character characteristic
-  // The AT command has the ability to set a default value but this helper function doesn't
+  // WRITE_WO_RESP: write without response is necessary to allow the WebBLE app on iOS
+  // to write, that app doesn't support write with a response 
   iconCharCharacteristicId = gatt.addCharacteristic(0x2345, GATT_CHARS_PROPERTIES_WRITE_WO_RESP | GATT_CHARS_PROPERTIES_READ, 
     1, 5, BLE_DATATYPE_STRING, "identifier char");
   if( iconCharCharacteristicId == 0 ) {
@@ -454,6 +455,7 @@ void setup(void) {
   }
 
 
+  // The AT command has the ability to set a default value but the helper function above doesn't
   // set the default value of the iconChar
   // this assumes the string is always null terminated. That should be the case if the userConfig
   // was initialized correctly.

--- a/thermoscope-bluefruit.ino
+++ b/thermoscope-bluefruit.ino
@@ -447,7 +447,7 @@ void setup(void) {
 
   // Add icon character characteristic
   // The AT command has the ability to set a default value but this helper function doesn't
-  iconCharCharacteristicId = gatt.addCharacteristic(0x2345, GATT_CHARS_PROPERTIES_WRITE | GATT_CHARS_PROPERTIES_READ, 
+  iconCharCharacteristicId = gatt.addCharacteristic(0x2345, GATT_CHARS_PROPERTIES_WRITE_WO_RESP | GATT_CHARS_PROPERTIES_READ, 
     1, 5, BLE_DATATYPE_STRING, "identifier char");
   if( iconCharCharacteristicId == 0 ) {
     error(F("Couldn't add icon characteristic"));


### PR DESCRIPTION
Allows the WebBLE iOS app to successfully set the thermoscope icon.